### PR TITLE
refactor: rename OpenDidException and add addMinutesToCurrentTimeString method

### DIFF
--- a/source/did-common-sdk-server/build.gradle
+++ b/source/did-common-sdk-server/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'org.omnione.did'
-version = '1.0.0'
+version = '1.0.1'
 sourceCompatibility = '17'
 
 configurations {

--- a/source/did-common-sdk-server/src/main/java/org/omnione/did/common/exception/CommonSdkException.java
+++ b/source/did-common-sdk-server/src/main/java/org/omnione/did/common/exception/CommonSdkException.java
@@ -7,7 +7,7 @@ package org.omnione.did.common.exception;
  *
  */
 
-public class OpenDidException extends RuntimeException{
+public class CommonSdkException extends RuntimeException{
     private ErrorCode errorCode;
     private ErrorResponse errorResponse;
 
@@ -16,7 +16,7 @@ public class OpenDidException extends RuntimeException{
      *
      * @param errorCode The ErrorCode enum value representing the specific error.
      */
-    public OpenDidException(ErrorCode errorCode) {
+    public CommonSdkException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
@@ -26,7 +26,7 @@ public class OpenDidException extends RuntimeException{
      *
      * @param errorResponse The ErrorResponse object representing the specific error.
      */
-    public OpenDidException(ErrorResponse errorResponse) {
+    public CommonSdkException(ErrorResponse errorResponse) {
         super(errorResponse.getDescription());
         this.errorResponse = errorResponse;
     }

--- a/source/did-common-sdk-server/src/main/java/org/omnione/did/common/util/DateTimeUtil.java
+++ b/source/did-common-sdk-server/src/main/java/org/omnione/did/common/util/DateTimeUtil.java
@@ -1,7 +1,7 @@
 package org.omnione.did.common.util;
 
 import org.omnione.did.common.exception.ErrorCode;
-import org.omnione.did.common.exception.OpenDidException;
+import org.omnione.did.common.exception.CommonSdkException;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -152,7 +152,7 @@ public class DateTimeUtil {
             return secondDateTime.isAfter(firstDateTime);
         } catch (DateTimeParseException e) {
             System.out.println("Error: One of the date-time strings is not valid: " + e.getMessage());
-            throw new OpenDidException(ErrorCode.INVALID_DATE_TIME);
+            throw new CommonSdkException(ErrorCode.INVALID_DATE_TIME);
         }
     }
 
@@ -166,5 +166,11 @@ public class DateTimeUtil {
      */
     public static Instant getMaxUTCTime() {
         return LocalDateTime.of(9999, 12, 31, 23, 59, 59).toInstant(ZoneOffset.UTC);
+    }
+
+    public static String addMinutesToCurrentTimeString(int minutes) {
+        ZonedDateTime utcNow = ZonedDateTime.now(ZoneId.of("UTC")).plus(minutes, ChronoUnit.MINUTES);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'");
+        return utcNow.format(formatter);
     }
 }

--- a/source/did-common-sdk-server/src/main/java/org/omnione/did/common/util/DateTimeUtil.java
+++ b/source/did-common-sdk-server/src/main/java/org/omnione/did/common/util/DateTimeUtil.java
@@ -173,4 +173,10 @@ public class DateTimeUtil {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'");
         return utcNow.format(formatter);
     }
+
+    public static String addSecondsToCurrentTimeString(int seconds) {
+        ZonedDateTime utcNow = ZonedDateTime.now(ZoneId.of("UTC")).plus(seconds, ChronoUnit.SECONDS);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'");
+        return utcNow.format(formatter);
+    }
 }

--- a/source/did-common-sdk-server/src/main/java/org/omnione/did/common/util/HttpClientUtil.java
+++ b/source/did-common-sdk-server/src/main/java/org/omnione/did/common/util/HttpClientUtil.java
@@ -3,7 +3,7 @@ package org.omnione.did.common.util;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.omnione.did.common.exception.ErrorCode;
 import org.omnione.did.common.exception.HttpClientException;
-import org.omnione.did.common.exception.OpenDidException;
+import org.omnione.did.common.exception.CommonSdkException;
 
 import java.io.IOException;
 import java.net.URI;
@@ -22,9 +22,9 @@ public class HttpClientUtil {
      * Send an HTTP GET request to the given URL and returns the response body as a String.
      * @param url URL to send the request to
      * @return Response body as a String
-     * @throws OpenDidException if the HTTP request fails
+     * @throws CommonSdkException if the HTTP request fails
      */
-    public static String getData(String url) {
+    public static String getData(String url) throws HttpClientException {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
@@ -34,13 +34,14 @@ public class HttpClientUtil {
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             int statusCode = response.statusCode();
             if (statusCode < 200 || statusCode >= 300) {
-                throw new OpenDidException(ErrorCode.HTTP_CLIENT_ERROR);
+                throw new HttpClientException(statusCode, response.body());
             }
             return response.body();
         } catch (IOException | InterruptedException e) {
-            throw new OpenDidException(ErrorCode.HTTP_CLIENT_ERROR);
+            throw new CommonSdkException(ErrorCode.HTTP_CLIENT_ERROR);
+        } catch (HttpClientException e) {
+            throw e;
         }
-
     }
 
     /**
@@ -48,9 +49,9 @@ public class HttpClientUtil {
      * @param url URL to send the request to
      * @param responseType Class type to parse the response body to
      * @return Response body parsed as the specified class type
-     * @throws OpenDidException if the HTTP request fails
+     * @throws CommonSdkException if the HTTP request fails
      */
-    public static <T> T getData(String url, Class<T> responseType){
+    public static <T> T getData(String url, Class<T> responseType) throws HttpClientException {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
@@ -62,12 +63,13 @@ public class HttpClientUtil {
             if (statusCode >= 200 && statusCode < 300) {
                 return objectMapper.readValue(response.body(), responseType);
             } else {
-                throw new OpenDidException(ErrorCode.HTTP_CLIENT_ERROR);
+                throw new HttpClientException(statusCode, response.body());
             }
         } catch (IOException | InterruptedException e) {
-            throw new OpenDidException(ErrorCode.HTTP_CLIENT_ERROR);
+            throw new CommonSdkException(ErrorCode.HTTP_CLIENT_ERROR);
+        } catch (HttpClientException e) {
+            throw e;
         }
-
     }
 
     /**
@@ -75,7 +77,7 @@ public class HttpClientUtil {
      * @param url URL to send the request to
      * @param requestBody Request body to send
      * @return Response body as a String
-     * @throws OpenDidException if the HTTP request fails
+     * @throws CommonSdkException if the HTTP request fails
      */
     public static String postData(String url, String requestBody) throws IOException, InterruptedException, HttpClientException {
         try {
@@ -87,11 +89,13 @@ public class HttpClientUtil {
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             int statusCode = response.statusCode();
             if (statusCode < 200 || statusCode >= 300) {
-                throw new OpenDidException(ErrorCode.HTTP_CLIENT_ERROR);
+                throw new HttpClientException(statusCode, response.body());
             }
             return response.body();
         } catch (IOException | InterruptedException e) {
-            throw new OpenDidException(ErrorCode.HTTP_CLIENT_ERROR);
+            throw new CommonSdkException(ErrorCode.HTTP_CLIENT_ERROR);
+        } catch (HttpClientException e) {
+            throw e;
         }
     }
 
@@ -102,9 +106,9 @@ public class HttpClientUtil {
      * @param requestBody Request body to send
      * @param responseType Class type to parse the response body to
      * @return Response body parsed as the specified class type
-     * @throws OpenDidException if the HTTP request fails
+     * @throws CommonSdkException if the HTTP request fails
      */
-    public static <T> T postData(String url, String requestBody, Class<T> responseType) {
+    public static <T> T postData(String url, String requestBody, Class<T> responseType) throws HttpClientException {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
@@ -118,11 +122,12 @@ public class HttpClientUtil {
             if (statusCode >= 200 && statusCode < 300) {
                 return objectMapper.readValue(response.body(), responseType);
             } else {
-                throw new OpenDidException(ErrorCode.HTTP_CLIENT_ERROR);
+                throw new HttpClientException(statusCode, response.body());
             }
         } catch (IOException | InterruptedException e) {
-            throw new OpenDidException(ErrorCode.HTTP_CLIENT_ERROR);
+            throw new CommonSdkException(ErrorCode.HTTP_CLIENT_ERROR);
+        } catch (HttpClientException e) {
+            throw e;
         }
-
     }
 }

--- a/source/did-common-sdk-server/src/main/java/org/omnione/did/common/util/JsonUtil.java
+++ b/source/did-common-sdk-server/src/main/java/org/omnione/did/common/util/JsonUtil.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.omnione.did.common.exception.ErrorCode;
-import org.omnione.did.common.exception.OpenDidException;
+import org.omnione.did.common.exception.CommonSdkException;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -34,7 +34,7 @@ public class JsonUtil {
      * It returns the sorted JSON string.
      * @param obj  the object to serialize
      * @return the sorted JSON string
-     * @throws OpenDidException if an error occurs during serialization and sort
+     * @throws CommonSdkException if an error occurs during serialization and sort
      */
     public static String serializeAndSort(Object obj)  {
         try {
@@ -44,7 +44,7 @@ public class JsonUtil {
             String sortedJsonString = mapper.writeValueAsString(sortedNode);
             return removeEscapeCharactersExceptValues(sortedJsonString);
         } catch (JsonProcessingException e) {
-            throw new OpenDidException(ErrorCode.JSON_SERIALIZE_SORT_FAILED);
+            throw new CommonSdkException(ErrorCode.JSON_SERIALIZE_SORT_FAILED);
         }
 
     }
@@ -111,13 +111,13 @@ public class JsonUtil {
      * This method converts any object to a JSON string and returns the JSON string.
      * @param obj  the object to convert
      * @return the JSON string
-     * @throws OpenDidException if an error occurs during serialization
+     * @throws CommonSdkException if an error occurs during serialization
      */
     public static String serializeToJson(Object obj)  {
         try {
             return mapper.writeValueAsString(obj);
         } catch (JsonProcessingException e) {
-            throw new OpenDidException(ErrorCode.JSON_SERIALIZE_FAILED);
+            throw new CommonSdkException(ErrorCode.JSON_SERIALIZE_FAILED);
         }
     }
 
@@ -128,13 +128,13 @@ public class JsonUtil {
      * @param clazz  the class type of the
      * @param <T>  the class type of the object to deserialize
      * @return the deserialized object
-     * @throws OpenDidException if an error occurs during deserialization
+     * @throws CommonSdkException if an error occurs during deserialization
      */
     public static <T> T deserializeFromJson(String jsonString, Class<T> clazz) {
         try {
             return mapper.readValue(jsonString, clazz);
         } catch (JsonProcessingException e) {
-            throw new OpenDidException(ErrorCode.JSON_DESERIALIZE_FAILED);
+            throw new CommonSdkException(ErrorCode.JSON_DESERIALIZE_FAILED);
         }
     }
 

--- a/source/did-common-sdk-server/src/main/java/org/omnione/did/common/util/QrMaker.java
+++ b/source/did-common-sdk-server/src/main/java/org/omnione/did/common/util/QrMaker.java
@@ -1,6 +1,5 @@
 package org.omnione.did.common.util;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.EncodeHintType;
 import com.google.zxing.WriterException;
@@ -8,11 +7,10 @@ import com.google.zxing.client.j2se.MatrixToImageWriter;
 import com.google.zxing.common.BitMatrix;
 import com.google.zxing.qrcode.QRCodeWriter;
 import org.omnione.did.common.exception.ErrorCode;
-import org.omnione.did.common.exception.OpenDidException;
+import org.omnione.did.common.exception.CommonSdkException;
 import org.omnione.did.common.vo.QrImageData;
 
 import java.io.ByteArrayOutputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -31,7 +29,7 @@ public class QrMaker {
      *
      * @param data The data to be encoded in the QR code.
      * @return The QR code image data.
-     * @throws OpenDidException If the QR code generation fails.
+     * @throws CommonSdkException If the QR code generation fails.
      */
     public static QrImageData makeQrImage(final Object data) {
         byte[] qrImage;
@@ -62,10 +60,10 @@ public class QrMaker {
                 MatrixToImageWriter.writeToStream(bitMatrix, format, pngOutputStream);
                 return pngOutputStream.toByteArray();
             } catch (IOException e) {
-                throw new OpenDidException(ErrorCode.QR_CODE_IO_ERROR);
+                throw new CommonSdkException(ErrorCode.QR_CODE_IO_ERROR);
             }
         } catch (WriterException e) {
-            throw new OpenDidException(ErrorCode.QR_CODE_ENCODING_ERROR);
+            throw new CommonSdkException(ErrorCode.QR_CODE_ENCODING_ERROR);
         }
     }
 
@@ -76,7 +74,7 @@ public class QrMaker {
      * @param width The desired width of the QR code
      * @param height The desired height of the QR code
      * @return BitMatrix representation of the QR code
-     * @throws OpenDidException If there's an error during QR code generation
+     * @throws CommonSdkException If there's an error during QR code generation
      */
     public static BitMatrix makeQrBitMatrix(String contents, int width, int height) throws WriterException {
         Map<EncodeHintType, Object> hints = new HashMap<>();


### PR DESCRIPTION
## Description
<!-- Briefly describe the changes in this pull request. -->
- Renamed `OpenDidException` to `CommonSdkException`.
- Added `addMinutesToCurrentTimeString` method to the `DateTimeUtil` class.

## Changes
<!-- List your changes in detail and what reviewers should focus on -->
- **Refactored Exception Class**: Renamed `OpenDidException` to `CommonSdkException` to better represent general SDK exceptions.
- **Added a Utility Method**: Introduced `addMinutesToCurrentTimeString` method in `DateTimeUtil`, which adds a specified number of minutes to the current time string.

## Screenshots (Optional)
<!-- Attach screenshots or GIFs to show the changes, if applicable. -->
N/A

## Additional Comments (Optional)
<!-- Any other comments or information that reviewers should be aware of. -->
- Any existing references to `OpenDidException` should be updated to `CommonSdkException`.
- The `addMinutesToCurrentTimeString` method is designed to operate on the current time formatted as `HH:mm:ss`, performing minute-based calculations.
